### PR TITLE
Include path when both path and filename specified

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -136,12 +136,16 @@ class Downloader:
 
         if path is None and filename is None:
             raise ValueError("Either path or filename must be specified.")
+        elif path is None:
+            path = './'
+
+        path = pathlib.path(path)
         if not filename:
             filepath = partial(default_name, path)
         elif callable(filename):
             filepath = filename
+
         else:
-            path = pathlib.Path(path)
             # Define a function because get_file expects a callback
             def filepath(*args):
                 return path / filename

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -139,7 +139,7 @@ class Downloader:
         elif path is None:
             path = './'
 
-        path = pathlib.path(path)
+        path = pathlib.Path(path)
         if not filename:
             filepath = partial(default_name, path)
         elif callable(filename):

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import asyncio
 import contextlib
 import urllib.parse
@@ -133,15 +135,16 @@ class Downloader:
         overwrite = overwrite or self.overwrite
 
         if path is None and filename is None:
-            raise ValueError("either path or filename must be specified.")
+            raise ValueError("Either path or filename must be specified.")
         if not filename:
             filepath = partial(default_name, path)
         elif callable(filename):
             filepath = filename
         else:
+            path = pathlib.Path(path)
             # Define a function because get_file expects a callback
             def filepath(*args):
-                return filename
+                return path / filename
 
         if url.startswith("http"):
             get_file = partial(self._get_http, url=url, filepath_partial=filepath,


### PR DESCRIPTION
Currently if the filename and path are specified, path is ignored and the file is just downloaded to the current working directory. This should fix it. I've used pathlib because that's what I'm used to, not sure if it wants to be `os.path.join` instead.