### PR TITLE
Make parfive download faster using concurrent requests

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -372,22 +372,7 @@ class Downloader:
                                           total=get_http_size(resp))
                     else:
                         file_pb = None
-                    with open(str(filepath), 'wb') as fd:
-                        while True:
-                            chunk = await resp.content.read(chunksize)
-                            if not chunk:
-                                # Close the file progressbar
-                                if file_pb is not None:
-                                    file_pb.close()
-
-                                return str(filepath)
-
-                            # Write this chunk to the output file.
-                            fd.write(chunk)
-
-                            # Update the progressbar for file
-                            if file_pb is not None:
-                                file_pb.update(chunksize)
+                    _write_response_to_file(resp, filepath, file_pb, chunksize)
 
         except Exception as e:
             raise FailedDownload(filepath_partial, url, e)
@@ -462,3 +447,22 @@ class Downloader:
 
         except Exception as e:
             raise FailedDownload(filepath_partial, url, e)
+
+
+async def _write_response_to_file(resp, filepath, file_pb, chunksize):
+    with open(str(filepath), 'wb') as fd:
+        while True:
+            chunk = await resp.content.read(chunksize)
+            if not chunk:
+                # Close the file progressbar
+                if file_pb is not None:
+                    file_pb.close()
+
+                return str(filepath)
+
+            # Write this chunk to the output file.
+            fd.write(chunk)
+
+            # Update the progressbar for file
+            if file_pb is not None:
+                file_pb.update(chunksize)

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -413,6 +413,12 @@ class Downloader:
 
     async def _write_worker(self, queue, file_pb, filepath):
         """
+        Worker for writing the downloaded chunk to the file. The downloaded chunk
+        is put into a asyncio Queue by a download worker. This worker gets the chunk from the
+        queue and write it to the file using the specified offset of the chunk.
+
+        Parameters
+        ----------
 
         queue: `asyncio.Queue`
              Queue for chunks
@@ -460,7 +466,7 @@ class Downloader:
             file will be downloaded.
 
         queue: `asyncio.Queue`
-             Queue for chunks
+             Queue to put the download chunks.
 
         kwargs : `dict`
             Extra keyword arguments are passed to `aiohttp.ClientSession.get`.
@@ -552,6 +558,17 @@ class Downloader:
             raise FailedDownload(filepath_partial, url, e)
 
     async def _ftp_download_worker(self, stream, queue):
+        """
+        Similar to `Downloader._http_download_worker`. See that function's documentation for more info.
+
+        Parameters
+        ----------
+
+        stream: `aioftp.StreamIO`
+            Stream of the file to be downloaded.
+        queue: `asyncio.Queue`
+             Queue to put the download chunks.
+        """
         offset = 0
         async for chunk in stream.iter_by_block():
             # Write this chunk to the output file.

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -378,7 +378,7 @@ class Downloader:
                     if max_splits and resp.headers.get('Accept-Ranges', None) == "bytes":
                         # XXX: int(?)
                         content_length = int(resp.headers['Content-length'])
-                        split_length = content_length//max_splits
+                        split_length = content_length // max_splits
                         ranges = [
                             [start, start + split_length]
                             for start in range(0, content_length, split_length)
@@ -389,12 +389,12 @@ class Downloader:
                         workers = []
                         for _range in ranges:
                             workers.append(
-                                asyncio.create_task(Downloader._ranged_http_producer(
+                                asyncio.create_task(Downloader._ranged_http_download(
                                     session, url, chunksize, _range, timeout, queue, **kwargs
                                 ))
                             )
                         consumer = asyncio.create_task(
-                            Downloader._ranged_http_consumer(queue, file_pb, filepath))
+                            Downloader._ranged_http_write(queue, file_pb, filepath))
                         await asyncio.gather(*workers)
                         await queue.join()
                         consumer.cancel()
@@ -421,7 +421,7 @@ class Downloader:
             raise FailedDownload(filepath_partial, url, e)
 
     @staticmethod
-    async def _ranged_http_consumer(queue, file_pb, filepath):
+    async def _ranged_http_write(queue, file_pb, filepath):
         """
 
         queue: `asyncio.Queue`
@@ -449,7 +449,7 @@ class Downloader:
                 queue.task_done()
 
     @staticmethod
-    async def _ranged_http_producer(session, url, chunksize, http_range, timeout, queue, **kwargs):
+    async def _ranged_http_download(session, url, chunksize, http_range, timeout, queue, **kwargs):
         """
         Worker for ranged http requests.
 

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -6,20 +6,8 @@ import pytest
 from pytest_localserver.http import WSGIServer
 
 from parfive.downloader import Downloader, Token, FailedDownload, Results
+from parfive.utils import sha256sum
 import hashlib
-
-
-def sha256sum(filename):
-    """
-    https://stackoverflow.com/a/44873382
-    """
-    h  = hashlib.sha256()
-    b  = bytearray(128*1024)
-    mv = memoryview(b)
-    with open(filename, 'rb', buffering=0) as f:
-        for n in iter(lambda : f.readinto(mv), 0):
-            h.update(mv[:n])
-    return h.hexdigest()
 
 
 def test_setup(event_loop):

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -6,6 +6,20 @@ import pytest
 from pytest_localserver.http import WSGIServer
 
 from parfive.downloader import Downloader, Token, FailedDownload, Results
+import hashlib
+
+
+def sha256sum(filename):
+    """
+    https://stackoverflow.com/a/44873382
+    """
+    h  = hashlib.sha256()
+    b  = bytearray(128*1024)
+    mv = memoryview(b)
+    with open(filename, 'rb', buffering=0) as f:
+        for n in iter(lambda : f.readinto(mv), 0):
+            h.update(mv[:n])
+    return h.hexdigest()
 
 
 def test_setup(event_loop):
@@ -25,6 +39,23 @@ def test_download(event_loop, httpserver, tmpdir):
                              headers={'Content-Disposition': "attachment; filename=testfile.fits"})
     dl = Downloader(loop=event_loop)
 
+    dl.enqueue_file(httpserver.url, path=Path(tmpdir), max_splits=None)
+
+    assert dl.queued_downloads == 1
+
+    f = dl.download()
+
+    assert len(f) == 1
+    assert Path(f[0]).name == "testfile.fits"
+    assert sha256sum(f[0]) == "a1c58cd340e3bd33f94524076f1fa5cf9a7f13c59d5272a9d4bc0b5bc436d9b3"
+
+
+def test_download_ranged_http(event_loop, httpserver, tmpdir):
+    tmpdir = str(tmpdir)
+    httpserver.serve_content('SIMPLE  = T',
+                             headers={'Content-Disposition': "attachment; filename=testfile.fits"})
+    dl = Downloader(loop=event_loop)
+
     dl.enqueue_file(httpserver.url, path=Path(tmpdir))
 
     assert dl.queued_downloads == 1
@@ -33,6 +64,7 @@ def test_download(event_loop, httpserver, tmpdir):
 
     assert len(f) == 1
     assert Path(f[0]).name == "testfile.fits"
+    assert sha256sum(f[0]) == "a1c58cd340e3bd33f94524076f1fa5cf9a7f13c59d5272a9d4bc0b5bc436d9b3"
 
 
 def test_download_partial(event_loop, httpserver, tmpdir):

--- a/parfive/tests/test_utils.py
+++ b/parfive/tests/test_utils.py
@@ -1,0 +1,11 @@
+import tempfile
+
+from parfive.utils import sha256sum
+
+
+def test_sha256sum():
+    tempfilename = tempfile.mktemp()
+    filehash = "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"
+    with open(tempfilename, 'w') as f:
+        f.write('A')
+    assert sha256sum(tempfilename) == filehash

--- a/parfive/utils.py
+++ b/parfive/utils.py
@@ -85,6 +85,10 @@ def replacement_filename(path):
 def get_filepath(filepath, overwrite):
     """
     Get the filepath to download to and ensure dir exists.
+
+    Returns
+    -------
+    `pathlib.Path`, `bool`
     """
     filepath = pathlib.Path(filepath)
     if filepath.exists():

--- a/parfive/utils.py
+++ b/parfive/utils.py
@@ -1,4 +1,5 @@
 import cgi
+import hashlib
 import pathlib
 from itertools import count
 
@@ -100,6 +101,19 @@ def get_filepath(filepath, overwrite):
         filepath.parent.mkdir(parents=True)
 
     return filepath, False
+
+
+def sha256sum(filename):
+    """
+    https://stackoverflow.com/a/44873382
+    """
+    h  = hashlib.sha256()
+    b  = bytearray(128*1024)
+    mv = memoryview(b)
+    with open(filename, 'rb', buffering=0) as f:
+        for n in iter(lambda : f.readinto(mv), 0):
+            h.update(mv[:n])
+    return h.hexdigest()
 
 
 class FailedDownload(Exception):


### PR DESCRIPTION
| File size | Eariler | With 12 concc conn |
| --------- | ------- | ------------------ |
| 10MB      | 10s     | 5s                 |
| 100MB     | 36s     | 21s                |
