### PR TITLE
Observer pattern for download state

### DIFF
--- a/parfive/state.py
+++ b/parfive/state.py
@@ -1,0 +1,52 @@
+from abc import ABCMeta, abstractmethod
+
+
+class DownloadState:
+    def __init__(self):
+        self._observers = []
+
+    def add_observer(self, observer):
+        self._observers.append(observer)
+
+    def update(self, chunk, offset=None):
+        for obs in self._observers:
+            obs.notify(chunk, offset)
+
+
+class Observer(metaclass=ABCMeta):
+    @abstractmethod
+    def notify(self, chunk):
+        """
+        Callback for the observer after a chunk has been downloaded
+
+        Paramaeters
+        -----------
+
+        chunk: bytes
+            The downloaded chunk of file.
+        """
+        raise NotImplementedError
+
+
+class FileWriter(Observer):
+    def __init__(self, filepath):
+        self._filepath = filepath
+        self._file = open(filepath, 'wb')
+
+    def notify(self, chunk, offset, *args):
+        self._write_chunk(chunk, offset)
+
+    def _write_chunk(self, chunk, offset):
+        # with open(self._filepath, 'wb') as f:
+        if offset:
+            self._file.seek(offset)
+        self._file.write(chunk)
+        self._file.flush()
+
+
+class DownloadProgress(Observer):
+    def __init__(self, file_pb):
+        self._file_pb = file_pb
+
+    def notify(self, chunk, *args):
+        self._file_pb.update(len(chunk))

--- a/parfive/state.py
+++ b/parfive/state.py
@@ -15,7 +15,7 @@ class DownloadState:
 
 class Observer(metaclass=ABCMeta):
     @abstractmethod
-    def notify(self, chunk):
+    def notify(self, chunk, offset):
         """
         Callback for the observer after a chunk has been downloaded
 
@@ -24,6 +24,9 @@ class Observer(metaclass=ABCMeta):
 
         chunk: bytes
             The downloaded chunk of file.
+
+        offset: int
+            Offset of the current chunk.
         """
         raise NotImplementedError
 
@@ -50,3 +53,12 @@ class DownloadProgress(Observer):
 
     def notify(self, chunk, *args):
         self._file_pb.update(len(chunk))
+
+
+class StateWriter(Observer):
+    def __init__(self, filename):
+        self._state_filename = filename + '.parfive'
+        self._state_file = open(self._state_filename, 'w')
+
+    def notify(self, chunk, offset, *args):
+        pass


### PR DESCRIPTION
This is an experimental refactoring of how download state is updated.

Right now HTTP downloads use the new pattern.

State could be initialized in the `enqueue_file` function with some effort. This would help reduce some of the `partial` magic and increase readability (up to debate, I guess).

The question is whether this over-engineering is necessary or not?