### PR TITLE
Add towncrier to handle changelogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+Parfive 1.0.0 (2019-05-01)
+==========================
+
+Features
+--------
+
+- First stable release of Parfive. (`#13 <https://github.com/Cadair/parfive/pull/13>`__)

--- a/changelog/16.feature
+++ b/changelog/16.feature
@@ -1,0 +1,1 @@
+Added CLI interface to Parfive.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,6 @@
+*********
+Changelog
+*********
+
+.. include:: rendered_changelog.txt
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,4 @@
-*********
 Changelog
 *********
 
-.. include:: rendered_changelog.txt
-
+.. include:: ../CHANGELOG.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@ Parfive
    :hidden:
 
    self
+   CHANGELOG
 
 Parfive is a small library for downloading files, its objective is to provide a
 simple API for queuing files for download and then providing excellent feedback

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Parfive
    :hidden:
 
    self
-   CHANGELOG
+   changelog
 
 Parfive is a small library for downloading files, its objective is to provide a
 simple API for queuing files for download and then providing excellent feedback

--- a/docs/rendered_changelog.txt
+++ b/docs/rendered_changelog.txt
@@ -1,0 +1,7 @@
+Parfive 1.0.0 (2019-05-01)
+=========================================
+
+Features
+--------
+
+- First stable release of Parfive. (`#13 <https://github.com/Cadair/parfive/pull/13>`__)

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -3,3 +3,4 @@ tqdm
 aioftp
 sunpy-sphinx-theme
 sphinx-astropy
+towncrier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
     package = "parfive"
     package_dir = "."
     directory = "changelog"
-    filename = "docs/CHANGELOG.rst"
+    filename = "docs/rendered_changelog.txt"
     issue_format = "`#{issue} <https://github.com/Cadair/parfive/pull/{issue}>`__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.towncrier]
+    package = "parfive"
+    package_dir = "."
+    directory = "changelog"
+    filename = "docs/CHANGELOG.rst"
+    issue_format = "`#{issue} <https://github.com/Cadair/parfive/pull/{issue}>`__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
     package = "parfive"
     package_dir = "."
     directory = "changelog"
-    filename = "docs/rendered_changelog.txt"
+    filename = "CHANGELOG.rst"
     issue_format = "`#{issue} <https://github.com/Cadair/parfive/pull/{issue}>`__"


### PR DESCRIPTION
This PR adds towncrier to handle changelogs.

Expect workflow:
- PRs add changelogs
- When it's time to be released, maintainer runs `towncrier` (which will remove the individual changelogs and renders the rst)

This means that there will be no changelog rendered for the dev version.