### PR TITLE
Attempt a more lenient content-disposition parser

### DIFF
--- a/parfive/tests/test_utils.py
+++ b/parfive/tests/test_utils.py
@@ -1,6 +1,10 @@
 import tempfile
+from collections import namedtuple
+from pathlib import Path
 
-from parfive.utils import sha256sum
+import pytest
+
+from parfive.utils import sha256sum, default_name
 
 
 def test_sha256sum():
@@ -9,3 +13,27 @@ def test_sha256sum():
     with open(tempfilename, 'w') as f:
         f.write('A')
     assert sha256sum(tempfilename) == filehash
+
+
+
+@pytest.fixture
+def resp(header):
+    resp = namedtuple("resp", ("headers",))
+    headers = {'Content-Disposition': header}
+    return resp(headers)
+
+
+@pytest.mark.parametrize("header", (
+    'attachment; filename="mdi_fd_M_96m_lev182_98611_98611.tar"\nContent-transfer-encoding: binary',
+    'attachment; filename="mdi_fd_M_96m_lev182_98611_98611.tar"',
+    'attachment; filename="mdi_fd_M_96m_lev182_98611_98611.tar"\n\nContent-transfer-encoding: binary',
+    'ajslkdj;skjdkj',
+    'attachment; wibble="hello"; filename="mdi_fd_M_96m_lev182_98611_98611.tar"',
+    'attachment; filename="mdi_fd_M_96m_lev182_98611_98611.tar"filename="kjdkfjds"kajskldj',
+    ''
+))
+def test_parse_content_disposition_header(resp, header):
+    url = "http://domain.ext/mdi_fd_M_96m_lev182_98611_98611.tar"
+    assert Path("./mdi_fd_M_96m_lev182_98611_98611.tar") == default_name(".", resp, url)
+
+

--- a/parfive/utils.py
+++ b/parfive/utils.py
@@ -30,6 +30,8 @@ def default_name(path, resp, url):
         if cdheader:
             value, params = cgi.parse_header(cdheader)
             name = params.get('filename', url_filename)
+            if name.count('"') >= 2:
+                name = name.split('"')[1]
         else:
             name = url_filename
     else:


### PR DESCRIPTION
This adds an extra class of Content-Disposition headers we can parse "correctly" including the troublesome one coming back from the VSO.

However, there are still a bunch which we can't. For instance this fails on:
```
'attachment; filename="mdi_fd_M_96m_lev182_98611_98611.tar"fiddles="kjdkfjds"kajskldj"'
```
as it finds the filename to be `fiddles=` which is arguably worse.