### PR TITLE
Reduce the number of splits we use by default.

### DIFF
--- a/changelog/37.bugfix.rst
+++ b/changelog/37.bugfix.rst
@@ -1,0 +1,2 @@
+Reduce the number of parallel connections to 25 (5 parallel files, 5 parallel
+downloads per file).

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -1,0 +1,14 @@
+Changelog
+=========
+
+parfive uses `towncrier <https://github.com/twisted/towncrier>`__ to build its changelog. 
+
+Please add a file to the ``changelog/`` directory with a filename matching ``<pr number>.<type>[.number].rst``. 
+
+The changelog types are:
+
+- ``.feature``: Signifying a new feature.
+- ``.bugfix``: Signifying a bug fix.
+- ``.doc``: Signifying a documentation improvement.
+- ``.removal``: Signifying a deprecation or removal of public API.
+- ``.misc``: A ticket has been closed, but it is not of interest to users.

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -343,7 +343,7 @@ class Downloader:
         return futures
 
     async def _get_http(self, session, *, url, filepath_partial, chunksize=100,
-                        file_pb=None, token, overwrite, timeouts, max_splits=12, **kwargs):
+                        file_pb=None, token, overwrite, timeouts, max_splits=5, **kwargs):
         """
         Read the file from the given url into the filename given by ``filepath_partial``.
 
@@ -370,7 +370,7 @@ class Downloader:
             A token for this download slot.
 
         max_splits: `int`
-            Number of maximum concurrent connections.
+            Number of maximum concurrent connections per file.
 
         kwargs : `dict`
             Extra keyword arguments are passed to `aiohttp.ClientSession.get`.

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -1,3 +1,4 @@
+import platform
 from pathlib import Path
 from unittest import mock
 from unittest.mock import patch
@@ -15,6 +16,7 @@ import sys
 import os
 import hashlib
 
+skip_windows = pytest.mark.skipif(platform.system() == 'Windows', reason="Windows.")
 
 def test_setup(event_loop):
     dl = Downloader(loop=event_loop)
@@ -315,6 +317,7 @@ def test_empty_retry():
     dl.retry(f)
 
 
+@skip_windows
 @pytest.mark.allow_hosts(True)
 def test_ftp(tmpdir):
     tmpdir = str(tmpdir)
@@ -330,6 +333,7 @@ def test_ftp(tmpdir):
     assert len(f.errors) == 3
 
 
+@skip_windows
 @pytest.mark.allow_hosts(True)
 def test_ftp_http(tmpdir, httpserver):
     tmpdir = str(tmpdir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,30 @@
 requires = ["setuptools", "setuptools_scm", "wheel"]
 build-backend = 'setuptools.build_meta'
 
+[ tool.gilesbot ]
+  [ tool.gilesbot.circleci_artifacts ]
+    enabled = true
+
+  [ tool.gilesbot.circleci_artifacts.giles ]
+    url = "html/index.html"
+    message = "Click details to preview the HTML documentation."
+
+  [ tool.gilesbot.pull_requests ]
+    enabled = true
+
+  [ tool.gilesbot.towncrier_changelog ]
+    enabled = true
+    verify_pr_number = true
+    changelog_skip_label = "No Changelog Entry Needed"
+    help_url = "https://github.com/Cadair/parfive/blob/master/changelog/README.rst"
+
+    changelog_missing_long = "There isn't a changelog file in this pull request. Please add a changelog file to the `changelog/` directory following the instructions in the changelog [README](https://github.com/Cadair/parfive/blob/master/changelog/README.rst)."
+
+    type_incorrect_long = "The changelog file you added is not one of the allowed types. Please use one of the types described in the changelog [README](https://github.com/Cadair/parfive/blob/master/changelog/README.rst)"
+
+    number_incorrect_long = "The number in the changelog file you added does not match the number of this pull request. Please rename the file."
+
+
 [tool.towncrier]
     package = "parfive"
     package_dir = "."


### PR DESCRIPTION
12 * 5 files if they are all from the same server leads to 60 parallel connections, which is probably way too many. 5 * 5 seems more reasonable.