### PR TITLE
Remove custom loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ htmlcov/
 .vscode/
 pip-wheel-metadata/
 parfive/version.py
+parfive/tests/.ipynb_checkpoints/
+parfive/tests/predicted-sunspot-radio-flux.txt
+

--- a/changelog/53.bugfix.rst
+++ b/changelog/53.bugfix.rst
@@ -1,0 +1,3 @@
+Handing a custom ``loop`` to `Downloader` now does nothing, and parfive spins
+up its own loop. This is to prepare for python 3.10 where support for passing
+custom loops to various `asyncio` methods will be removed.

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -19,7 +19,7 @@ from .utils import (FailedDownload, Token, default_name, get_filepath,
 
 try:
     import aioftp
-except ImportError:
+except ImportError:  # pragma: nocover
     aioftp = None
 
 

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -70,7 +70,7 @@ class Downloader:
                  loop=None, notebook=None, overwrite=False, headers=None):
 
         self.max_conn = max_conn
-        self._start_loop(loop)
+        self._init_queues()
 
         # Configure progress bars
         if notebook is None:
@@ -85,7 +85,7 @@ class Downloader:
         if headers is None or 'User-Agent' not in headers:
             self.headers = {'User-Agent': f"parfive/{parfive.__version__} aiohttp/{aiohttp.__version__} python/{sys.version[:5]}"}
 
-    def _start_loop(self, loop):
+    def _init_queues(self):
         # Setup queues
         self.http_queue = _QueueList()
         self.http_tokens = _QueueList()
@@ -260,8 +260,8 @@ class Downloader:
             file paths.
 
         """
-        # Restart the loop.
-        self._start_loop(None)
+        # Reset the queues
+        self._init_queues(None)
 
         for err in results.errors:
             self.enqueue_file(err.url, filename=err.filepath_partial)

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -263,7 +263,7 @@ class Downloader:
 
         """
         # Reset the queues
-        self._init_queues(None)
+        self._init_queues()
 
         for err in results.errors:
             self.enqueue_file(err.url, filename=err.filepath_partial)

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import os
 import sys
+import warnings
 
 import pathlib
 import urllib.parse
@@ -45,9 +46,7 @@ class Downloader:
         detailing the progress of each individual file being downloaded.
 
     loop : `asyncio.AbstractEventLoop`, optional
-        The event loop to use to download the files. If not specified a new
-        loop will be created and executed in a new thread so it does not
-        interfere with any currently running event loop.
+        No longer used, and will be removed in a future release.
 
     notebook : `bool`, optional
         If `True` tqdm will be used in notebook mode. If `None` an attempt will
@@ -69,6 +68,9 @@ class Downloader:
     def __init__(self, max_conn=5, progress=True, file_progress=True,
                  loop=None, notebook=None, overwrite=False, headers=None):
 
+        if loop:
+            warnings.warn('The loop argument is no longer used, and will be '
+                          'removed in a future release.')
         self.max_conn = max_conn
         self._init_queues()
 

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -97,10 +97,10 @@ class Downloader:
         asyncio.set_event_loop(self.loop)
 
         # Setup queues
-        self.http_queue = []  # asyncio.Queue(loop=self.loop)
-        self.http_tokens = [] # asyncio.Queue(maxsize=self.max_conn, loop=self.loop)
-        self.ftp_queue = []  # asyncio.Queue(loop=self.loop)
-        self.ftp_tokens = [] # asyncio.Queue(maxsize=self.max_conn, loop=self.loop)
+        self.http_queue = []
+        self.http_tokens = []
+        self.ftp_queue = []
+        self.ftp_tokens = []
         for i in range(self.max_conn):
             self.http_tokens.append(Token(i + 1))
             self.ftp_tokens.append(Token(i + 1))

--- a/parfive/tests/simple_download_test.ipynb
+++ b/parfive/tests/simple_download_test.ipynb
@@ -1,0 +1,377 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import parfive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dl = parfive.Downloader()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dl.enqueue_file(\"http://data.sunpy.org/sample-data/predicted-sunspot-radio-flux.txt\", path=\"./\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/0/data/"
+     ]
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "db630dac73074c248fb6ecc163e1fd75",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Files Downloaded', max=1.0, style=ProgressStyle(descripti…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "files = dl.download()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<parfive.results.Results object at 0x000000000000>\n",
+       "['predicted-sunspot-radio-flux.txt']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "files"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "nbreg": {
+   "diff_ignore": [
+    "/metadata/widgets"
+   ]
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0cc46587e5314f8a95e5373eed4af735": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "Files Downloaded: 100%",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_d3f4f43178564251aa135d08e87f47db",
+       "max": 1,
+       "min": 0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_ef5d56b1823d442c829e821516cdbff0",
+       "value": 1
+      }
+     },
+     "4a1f3a7b8acd4d1daeebd13033a5ba05": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "DescriptionStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "description_width": ""
+      }
+     },
+     "658c594e4c7f44e986c5e8d346e290ef": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "720f662a1e20406ba71816e33cbdbe30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c5a8b53e793f4b328543dd9fedd64b6f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_tooltip": null,
+       "layout": "IPY_MODEL_658c594e4c7f44e986c5e8d346e290ef",
+       "placeholder": "​",
+       "style": "IPY_MODEL_4a1f3a7b8acd4d1daeebd13033a5ba05",
+       "value": " 1/1 [00:00&lt;00:00, 10.57file/s]"
+      }
+     },
+     "d3f4f43178564251aa135d08e87f47db": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "db630dac73074c248fb6ecc163e1fd75": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_0cc46587e5314f8a95e5373eed4af735",
+        "IPY_MODEL_c5a8b53e793f4b328543dd9fedd64b6f"
+       ],
+       "layout": "IPY_MODEL_720f662a1e20406ba71816e33cbdbe30"
+      }
+     },
+     "ef5d56b1823d442c829e821516cdbff0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "1.5.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": "initial"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -20,7 +20,7 @@ skip_windows = pytest.mark.skipif(platform.system() == 'Windows', reason="Window
 
 
 def test_setup(event_loop):
-    dl = Downloader(loop=event_loop)
+    dl = Downloader()
 
     assert isinstance(dl, Downloader)
 

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -18,6 +18,7 @@ import hashlib
 
 skip_windows = pytest.mark.skipif(platform.system() == 'Windows', reason="Windows.")
 
+
 def test_setup(event_loop):
     dl = Downloader(loop=event_loop)
 

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -23,9 +23,9 @@ def test_setup(event_loop):
 
     assert isinstance(dl, Downloader)
 
-    assert dl.http_queue.qsize() == 0
+    assert len(dl.http_queue) == 0
     assert dl.http_tokens.qsize() == 5
-    assert dl.ftp_queue.qsize() == 0
+    assert len(dl.ftp_queue) == 0
     assert dl.ftp_tokens.qsize() == 5
 
 
@@ -405,7 +405,7 @@ def test_proxy_passed_as_kwargs_to_get(event_loop, tmpdir, url, proxy):
 
     assert patched.called, "`ClientSession._request` not called"
     assert list(patched.call_args) == [('GET', url),
-                                       {'allow_redirects': True, 
+                                       {'allow_redirects': True,
                                         'timeout': ClientTimeout(total=300, connect=None, sock_read=90, sock_connect=None),
                                         'proxy': proxy
                                        }]

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -24,9 +24,9 @@ def test_setup(event_loop):
     assert isinstance(dl, Downloader)
 
     assert len(dl.http_queue) == 0
-    assert dl.http_tokens.qsize() == 5
+    assert len(dl.http_tokens) == 5
     assert len(dl.ftp_queue) == 0
-    assert dl.ftp_tokens.qsize() == 5
+    assert len(dl.ftp_tokens) == 5
 
 
 def test_download(event_loop, httpserver, tmpdir):

--- a/parfive/utils.py
+++ b/parfive/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import cgi
 import hashlib
 import pathlib
@@ -152,3 +153,17 @@ class Token:
 
     def __str__(self):
         return f"Token {self.n}"
+
+
+class _QueueList(list):
+    """
+    A list, with an extra method that empties the list and puts
+    it into a `asyncio.Queue`. Creating the queue can only be done inside
+    a running asyncio loop.
+    """
+    def generate_queue(self, maxsize=0):
+        queue = asyncio.Queue(maxsize=maxsize)
+        for item in self:
+            queue.put_nowait(item)
+        self.clear()
+        return queue

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
 
 [options]
 python_requires = >=3.7
-include_package_data = True
 install_requires =
   tqdm
   aiohttp
@@ -28,15 +27,11 @@ console_scripts =
 [options.extras_require]
 ftp = aioftp>=0.17.1
 test =
-  pytest<6  # pinned due to https://github.com/chrisjsewell/pytest-notebook/issues/9
+  pytest
   pytest-localserver
   pytest-asyncio
   pytest-socket
   pytest-cov
-  pytest-notebook
-  coverage<5  # pinned due to https://github.com/chrisjsewell/pytest-notebook/issues/6
-  nbconvert<6
-  ipywidgets
 docs =
   sunpy-sphinx-theme
   sphinx-automodapi
@@ -47,21 +42,11 @@ ignore = I100,I101,I102,I103,I104,I201
 
 [tool:pytest]
 addopts = --allow-hosts=127.0.0.1,::1
-nb_test_files = True
-nb_coverage = True
-nb_diff_ignore =
-    /metadata/language_info
-nb_diff_replace =
-    /cells/*/outputs/*/data/text/plain 0x.{12}> "0x000000000000"
-    /cells/*/outputs/* model_id:.* ""
 
 [coverage:run]
+source = parfive
 omit =
    parfive/conftest.py
    parfive/*setup*
    parfive/tests/*
    parfive/__init__*
-   */parfive/conftest.py
-   */parfive/*setup*
-   */parfive/tests/*
-   */parfive/__init__*

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
 
 [options]
 python_requires = >=3.7
+include_package_data = True
 install_requires =
   tqdm
   aiohttp
@@ -34,6 +35,7 @@ test =
   pytest-cov
   pytest-notebook
   coverage<5  # pinned due to https://github.com/chrisjsewell/pytest-notebook/issues/6
+  nbconvert<6
   ipywidgets
 docs =
   sunpy-sphinx-theme
@@ -51,11 +53,15 @@ nb_diff_ignore =
     /metadata/language_info
 nb_diff_replace =
     /cells/*/outputs/*/data/text/plain 0x.{12}> "0x000000000000"
+    /cells/*/outputs/* model_id:.* ""
 
 [coverage:run]
-source = parfive
 omit =
    parfive/conftest.py
    parfive/*setup*
    parfive/tests/*
    parfive/__init__*
+   */parfive/conftest.py
+   */parfive/*setup*
+   */parfive/tests/*
+   */parfive/__init__*

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,14 @@ console_scripts =
 [options.extras_require]
 ftp = aioftp>=0.17.1
 test =
-  pytest
+  pytest<6  # pinned due to https://github.com/chrisjsewell/pytest-notebook/issues/9
   pytest-localserver
   pytest-asyncio
   pytest-socket
   pytest-cov
+  pytest-notebook
+  coverage<5  # pinned due to https://github.com/chrisjsewell/pytest-notebook/issues/6
+  ipywidgets
 docs =
   sunpy-sphinx-theme
   sphinx-automodapi
@@ -42,6 +45,12 @@ ignore = I100,I101,I102,I103,I104,I201
 
 [tool:pytest]
 addopts = --allow-hosts=127.0.0.1,::1
+nb_test_files = True
+nb_coverage = True
+nb_diff_ignore =
+    /metadata/language_info
+nb_diff_replace =
+    /cells/*/outputs/*/data/text/plain 0x.{12}> "0x000000000000"
 
 [coverage:run]
 source = parfive

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ extras =
   test
   docs: docs
 commands =
-    py38,py37: pytest --cov=parfive {posargs}
+    py38,py37: pytest --pyargs parfive --cov=parfive {posargs}
     docs: sphinx-build docs docs/_build/html -W -b html

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ extras =
   test
   docs: docs
 commands =
-    py38,py37: pytest --pyargs parfive --cov=parfive {posargs}
-    docs: sphinx-build docs docs/_build/html -W -b html
+    py38,py37: pytest --cov=parfive {posargs}
+    docs: sphinx-build docs docs/_build/html -W -b html {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ extras =
   test
   docs: docs
 commands =
-    py38,py37: pytest --cov {posargs}
+    py38,py37: pytest --cov=parfive {posargs}
     docs: sphinx-build docs docs/_build/html -W -b html


### PR DESCRIPTION
This is a attempt to fix https://github.com/Cadair/parfive/issues/41 by removing the custom loop. Now `Downloader.download()` spins up it's own loop automatically using `asyncio.run`, as recommended in the python docs.

This makes the following breaking changes:
- Converts `http_queue` etc. to lists instead of queues. This is so they can be created outside of an asyncio context.
- Ignores the `loop` argument.

I think these would both need to be deprecated before this change is merged, but I thought I would open this PR for discussion on a way forward (and as a change for me to learn about asyncio). I would be happy to make the required deprecations if this is the correct way to go.