### PR TITLE
Generate tokens at download time

### DIFF
--- a/changelog/56.bugfix.rst
+++ b/changelog/56.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug where downloads fail if ``max_conn`` is changed after construction of
+the `parfive.Downloader` instance.


### PR DESCRIPTION
Fixes https://github.com/Cadair/parfive/issues/55. The issue was `max_conn` being reduced in between `Downloader` being created, and the downloads being run. The tokens are now created at download time, which means `max_conn` can be safely modified after creation.

Needs a test.