### PR TITLE
Log download errors

### DIFF
--- a/changelog/58.feature.rst
+++ b/changelog/58.feature.rst
@@ -1,2 +1,2 @@
-Any errors encountered downloading files are now logged to the build in python
+Any errors encountered downloading files are now logged to the built in python
 logging system at the INFO level.

--- a/changelog/58.feature.rst
+++ b/changelog/58.feature.rst
@@ -1,0 +1,2 @@
+Any errors encountered downloading files are now logged to the build in python
+logging system at the INFO level.

--- a/parfive/__init__.py
+++ b/parfive/__init__.py
@@ -1,8 +1,9 @@
 """parfive - A parallel file downloader using asyncio."""
 from .downloader import Downloader
 from .results import Results
+from .utils import log
 
-__all__ = ['Downloader', 'Results']
+__all__ = ['Downloader', 'Results', 'log']
 
 
 try:

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -238,6 +238,8 @@ class Downloader:
         for res in dl_results:
             if isinstance(res, FailedDownload):
                 results.add_error(res.filepath_partial, res.url, res.exception)
+                parfive.log.debug(f'{res.url} failed to download with exception\n'
+                                  f'{res.exception}')
             elif isinstance(res, Exception):
                 raise res
             else:

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -238,8 +238,8 @@ class Downloader:
         for res in dl_results:
             if isinstance(res, FailedDownload):
                 results.add_error(res.filepath_partial, res.url, res.exception)
-                parfive.log.debug(f'{res.url} failed to download with exception\n'
-                                  f'{res.exception}')
+                parfive.log.info(f'{res.url} failed to download with exception\n'
+                                 f'{res.exception}')
             elif isinstance(res, Exception):
                 raise res
             else:

--- a/parfive/utils.py
+++ b/parfive/utils.py
@@ -1,10 +1,15 @@
 import cgi
 import asyncio
 import hashlib
+import logging
 import pathlib
 from itertools import count
 
-__all__ = ['run_in_thread', 'Token', 'FailedDownload', 'default_name', 'in_notebook']
+__all__ = ['run_in_thread', 'Token', 'FailedDownload', 'default_name',
+           'in_notebook']
+
+
+log = logging.getLogger('parfive')
 
 
 def in_notebook():


### PR DESCRIPTION
Log any download errors at debug level. Personally I think these should be warnings, but I understand that might be a bit verbose by default.