### PR TITLE
Put currentmodule in doc index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: parfive
+
 Parfive
 =======
 


### PR DESCRIPTION
I'm struggling to get \`parfive\` to link in the sunpy docs, and I think it's because this page is missing a `currentmodule` directive.