### PR TITLE
Add a `Downloader.simple_download` method to easily download a list of URLs to a single directory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,10 +40,10 @@ A simple example is::
   dl.enqueue_file("http://data.sunpy.org/sample-data/predicted-sunspot-radio-flux.txt", path="./")
   files = dl.download()
 
-It's also possible to download a list of URLs to a single destination using the `parfive.Downloader.quick_download` method::
+It's also possible to download a list of URLs to a single destination using the `parfive.Downloader.simple_download` method::
 
   from parfive import Downloader
-  files = Downloader.quick_download(['http://212.183.159.230/5MB.zip' 'http://212.183.159.230/10MB.zip'], path="./")
+  files = Downloader.simple_download(['http://212.183.159.230/5MB.zip' 'http://212.183.159.230/10MB.zip'], path="./")
 
 Parfive also bundles a CLI. The following example will download the two files concurrently::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,11 @@ A simple example is::
   dl.enqueue_file("http://data.sunpy.org/sample-data/predicted-sunspot-radio-flux.txt", path="./")
   files = dl.download()
 
+It's also possible to download a list of URLs to a single destination using the `parfive.Downloader.quick_download` method::
+
+  from parfive import Downloader
+  files = Downloader.quick_download(['http://212.183.159.230/5MB.zip' 'http://212.183.159.230/10MB.zip'], path="./")
+
 Parfive also bundles a CLI. The following example will download the two files concurrently::
 
   $ parfive 'http://212.183.159.230/5MB.zip' 'http://212.183.159.230/10MB.zip'

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -377,7 +377,7 @@ class Downloader:
         return results
 
     @classmethod
-    def quick_download(cls, urls, *, path=None, overwrite=None):
+    def simple_download(cls, urls, *, path=None, overwrite=None):
         """
         Download a series of URLs to a single destination.
 

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -376,6 +376,34 @@ class Downloader:
 
         return results
 
+    @classmethod
+    def quick_download(cls, urls, *, path=None, overwrite=None):
+        """
+        Download a series of URLs to a single destination.
+
+        Parameters
+        ----------
+        urls : iterable
+            A sequence of URLs to download.
+
+        path : `pathlib.Path`, optional
+            The destination directory for the downloaded files.
+
+        overwrite: `bool`, optional
+            Overwrite the files at the destination directory. If `False` the
+            URL will not be downloaded if a file with the corresponding
+            filename already exists.
+
+        Returns
+        -------
+        `parfive.Results`
+            A list of files downloaded.
+        """
+        dl = cls()
+        for url in urls:
+            dl.enqueue_file(url, path=path, overwrite=overwrite)
+        return dl.download()
+
     def _get_main_pb(self, total):
         """
         Return the tqdm instance if we want it, else return a contextmanager
@@ -478,6 +506,9 @@ class Downloader:
                                   resp.request_info.method,
                                   resp.request_info.url,
                                   resp.request_info.headers)
+                parfive.log.debug("Response received from %s with headers=%s",
+                                  resp.request_info.url,
+                                  resp.headers)
                 if resp.status != 200:
                     raise FailedDownload(filepath_partial, url, resp)
                 else:
@@ -622,6 +653,9 @@ class Downloader:
                               resp.request_info.method,
                               resp.request_info.url,
                               resp.request_info.headers)
+            parfive.log.debug("Response received from %s with headers=%s",
+                              resp.request_info.url,
+                              resp.headers)
             while True:
                 chunk = await resp.content.read(chunksize)
                 if not chunk:

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -48,6 +48,15 @@ def test_download(httpserver, tmpdir):
     validate_test_file(f)
 
 
+def test_qucik_download(httpserver, tmpdir):
+    tmpdir = str(tmpdir)
+    httpserver.serve_content('SIMPLE  = T',
+                             headers={'Content-Disposition': "attachment; filename=testfile.fits"})
+
+    f = Downloader.quick_download([httpserver.url], path=Path(tmpdir))
+    validate_test_file(f)
+
+
 def test_changed_max_conn(httpserver, tmpdir):
     # Check that changing max_conn works after creating Downloader
     tmpdir = str(tmpdir)

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -48,12 +48,12 @@ def test_download(httpserver, tmpdir):
     validate_test_file(f)
 
 
-def test_qucik_download(httpserver, tmpdir):
+def test_simple_download(httpserver, tmpdir):
     tmpdir = str(tmpdir)
     httpserver.serve_content('SIMPLE  = T',
                              headers={'Content-Disposition': "attachment; filename=testfile.fits"})
 
-    f = Downloader.quick_download([httpserver.url], path=Path(tmpdir))
+    f = Downloader.simple_download([httpserver.url], path=Path(tmpdir))
     validate_test_file(f)
 
 


### PR DESCRIPTION
fixes #72 