### PR TITLE
fix issue with small files

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -534,7 +534,7 @@ class Downloader:
 
                     if not DISABLE_RANGE and max_splits and resp.headers.get('Accept-Ranges', None) == "bytes":
                         content_length = int(resp.headers['Content-length'])
-                        split_length = content_length // max_splits
+                        split_length = max(1, content_length // max_splits)
                         ranges = [
                             [start, start + split_length]
                             for start in range(0, content_length, split_length)

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -534,7 +534,7 @@ class Downloader:
 
                     if not DISABLE_RANGE and max_splits and resp.headers.get('Accept-Ranges', None) == "bytes":
                         content_length = int(resp.headers['Content-length'])
-                        split_length = max(1, content_length // max_splits)
+                        split_length = content_length // max_splits
                         ranges = [
                             [start, start + split_length]
                             for start in range(0, content_length, split_length)

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -102,7 +102,7 @@ def test_download_ranged_http(httpserver, tmpdir):
 def test_regression_download_ranged_http(httpserver, tmpdir):
     tmpdir = str(tmpdir)
     httpserver.serve_content('S',
-                             headers={'Content-Disposition': "attachment; filename=testfile.fits", 
+                             headers={'Content-Disposition': "attachment; filename=testfile.fits",
                                       'Accept-Ranges': "bytes"})
     dl = Downloader()
 

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -98,6 +98,7 @@ def test_download_ranged_http(httpserver, tmpdir):
     f = dl.download()
     validate_test_file(f)
 
+
 def test_regression_download_ranged_http(httpserver, tmpdir):
     tmpdir = str(tmpdir)
     httpserver.serve_content('S',
@@ -111,6 +112,7 @@ def test_regression_download_ranged_http(httpserver, tmpdir):
 
     f = dl.download()
     assert len(f.errors) == 0, f.errors
+
 
 def test_download_partial(httpserver, tmpdir):
     tmpdir = str(tmpdir)

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -98,6 +98,18 @@ def test_download_ranged_http(httpserver, tmpdir):
     f = dl.download()
     validate_test_file(f)
 
+def test_regression_download_ranged_http(httpserver, tmpdir):
+    tmpdir = str(tmpdir)
+    httpserver.serve_content('S',
+                             headers={'Content-Disposition': "attachment; filename=testfile.fits", 'Accept-Ranges': "bytes"})
+    dl = Downloader()
+
+    dl.enqueue_file(httpserver.url, path=Path(tmpdir))
+
+    assert dl.queued_downloads == 1
+
+    f = dl.download()
+    assert len(f.errors) == 0, f.errors
 
 def test_download_partial(httpserver, tmpdir):
     tmpdir = str(tmpdir)

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -101,7 +101,8 @@ def test_download_ranged_http(httpserver, tmpdir):
 def test_regression_download_ranged_http(httpserver, tmpdir):
     tmpdir = str(tmpdir)
     httpserver.serve_content('S',
-                             headers={'Content-Disposition': "attachment; filename=testfile.fits", 'Accept-Ranges': "bytes"})
+                             headers={'Content-Disposition': "attachment; filename=testfile.fits", 
+                                      'Accept-Ranges': "bytes"})
     dl = Downloader()
 
     dl.enqueue_file(httpserver.url, path=Path(tmpdir))


### PR DESCRIPTION
In case a small file is being downloaded (in my case a text file with a single digit number). The download fails since `split_length` goes to 0, which is not supported by the builtin  range command.

Also managed to add a regression test for this single case.