### PR TITLE
Do not split download if no "Content-length"

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -532,7 +532,7 @@ class Downloader:
                     writer = asyncio.create_task(
                         self._write_worker(downloaded_chunk_queue, file_pb, filepath))
 
-                    if not DISABLE_RANGE and max_splits and resp.headers.get('Accept-Ranges', None) == "bytes":
+                    if not DISABLE_RANGE and max_splits and resp.headers.get('Accept-Ranges', None) == "bytes" and 'Content-length' in resp.headers:
                         content_length = int(resp.headers['Content-length'])
                         split_length = max(1, content_length // max_splits)
                         ranges = [


### PR DESCRIPTION
The server I was downloading from does not return a "Content-length" in the response, leading to a KeyError and a failed download.

I did get it working when DISABLE_RANGE was set, but since this is an environment variable I cannot change this in the code, since other servers I download from do return "Content-length".

I have now added an extra statement to check if "Content-length" is in the response, otherwise do not try and split the download.

Let me know what you think.