### PR TITLE
Fix a bug where only HTTP 200 response codes were accepted as success

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -687,7 +687,7 @@ class Downloader:
                 resp.headers,
             )
 
-            if resp.status != 200:
+            if resp.status < 200 or resp.status >= 300:
                 raise MultiPartDownloadError(resp)
 
             while True:

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -687,7 +687,7 @@ class Downloader:
                 resp.headers,
             )
 
-            if resp.status < 200 or resp.status >= 300:
+            if resp.status < 200 or resp.status > 300:
                 raise MultiPartDownloadError(resp)
 
             while True:


### PR DESCRIPTION
Http 2xx range are all success statuses, so should be accepted without raising `MultiPartDownloadError`.