### PR TITLE
Do not use pydantic for settings validation

### DIFF
--- a/parfive/config.py
+++ b/parfive/config.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from typing_extensions import Literal  # type: ignore
 
-from dataclasses import InitVar, field, asdict, dataclass
+from dataclasses import field, dataclass
 
 import aiohttp
 

--- a/parfive/config.py
+++ b/parfive/config.py
@@ -1,15 +1,16 @@
 import os
 import platform
 import warnings
-from typing import Any, Dict, Union, Optional
+from typing import Dict, Union, Optional
 
 try:
     from typing import Literal  # Added in Python 3.8
 except ImportError:
     from typing_extensions import Literal  # type: ignore
 
+from dataclasses import InitVar, field, asdict, dataclass
+
 import aiohttp
-from pydantic import BaseSettings, Field
 
 import parfive
 from parfive.utils import ParfiveUserWarning
@@ -25,32 +26,18 @@ def _default_headers():
     }
 
 
-class EnvConfig(BaseSettings):
-    """
-    Configuration read from environment variables.
-    """
-
-    # Session scoped env vars
-    serial_mode: bool = Field(False, env="PARFIVE_SINGLE_DOWNLOAD")
-    disable_range: bool = Field(False, env="PARFIVE_DISABLE_RANGE")
-    hide_progress: bool = Field(False, env="PARFIVE_HIDE_PROGRESS")
-    debug_logging: bool = Field(False, env="PARFIVE_DEBUG")
-    timeout_total: float = Field(0, env="PARFIVE_TOTAL_TIMEOUT")
-    timeout_sock_read: float = Field(90, env="PARFIVE_SOCK_READ_TIMEOUT")
-    override_use_aiofiles: bool = Field(False, env="PARFIVE_OVERWRITE_ENABLE_AIOFILES")
-
-
-class SessionConfig(BaseSettings):
+@dataclass
+class SessionConfig:
     """
     Configuration options for `parfive.Downloader`.
     """
 
-    http_proxy: Optional[str] = Field(None, env="HTTP_PROXY")
+    http_proxy: Optional[str] = None
     """
     The URL of a proxy to use for HTTP requests. Will default to the value of
     the ``HTTP_PROXY`` env var.
     """
-    https_proxy: Optional[str] = Field(None, env="HTTPS_PROXY")
+    https_proxy: Optional[str] = None
     """
     The URL of a proxy to use for HTTPS requests. Will default to the value of
     the ``HTTPS_PROXY`` env var.
@@ -75,7 +62,7 @@ class SessionConfig(BaseSettings):
     If `True` (the default) a progress bar will be shown for every file if any
     progress bars are shown.
     """
-    notebook: Optional[bool] = None
+    notebook: Union[bool, None] = None
     """
     If `None` `tqdm` will automatically detect if it can draw rich IPython
     Notebook progress bars. If `False` or `True` notebook mode will be forced
@@ -85,7 +72,7 @@ class SessionConfig(BaseSettings):
     """
     If not `None` configure the logger to log to stderr with this log level.
     """
-    use_aiofiles: bool = Field(False)
+    use_aiofiles: Optional[bool] = None
     """
     Enables using `aiofiles` to write files to disk in their own thread pool.
 
@@ -105,14 +92,13 @@ class SessionConfig(BaseSettings):
     overridden by the ``PARFIVE_TOTAL_TIMEOUT`` and
     ``PARFIVE_SOCK_READ_TIMEOUT`` environment variables.
     """
-    aiohttp_session_kwargs: Dict = Field(default_factory=dict)
+    aiohttp_session_kwargs: Dict = field(default_factory=dict)
     """
     Any extra keyword arguments to be passed to `aiohttp.ClientSession`.
 
     Note that the `headers` keyword argument is handled separately, so should
     not be included in this dict.
     """
-    env: EnvConfig = Field(default_factory=EnvConfig)
 
     @staticmethod
     def _aiofiles_importable():
@@ -123,8 +109,7 @@ class SessionConfig(BaseSettings):
         return True
 
     def _compute_aiofiles(self, use_aiofiles):
-        if self.env.override_use_aiofiles:
-            use_aiofiles = True
+        use_aiofiles = use_aiofiles or "PARFIVE_OVERWRITE_ENABLE_AIOFILES" in os.environ
         if use_aiofiles and not self._aiofiles_importable():
             warnings.warn(
                 "Can not use aiofiles even though use_aiofiles is set to True as aiofiles can not be imported.",
@@ -133,23 +118,44 @@ class SessionConfig(BaseSettings):
             use_aiofiles = False
         return use_aiofiles
 
-    def __init__(self, **data):
-        super().__init__(**data)
+    def __post_init__(self):
         if self.timeouts is None:
             timeouts = {
-                "total": self.env.timeout_total,
-                "sock_read": self.env.timeout_sock_read,
+                "total": float(os.environ.get("PARFIVE_TOTAL_TIMEOUT", 0)),
+                "sock_read": float(os.environ.get("PARFIVE_SOCK_READ_TIMEOUT", 90)),
             }
             self.timeouts = aiohttp.ClientTimeout(**timeouts)
+        if self.http_proxy is None:
+            self.http_proxy = os.environ.get("HTTP_PROXY", None)
+        if self.https_proxy is None:
+            self.https_proxy = os.environ.get("HTTPS_PROXY", None)
 
         if self.use_aiofiles is not None:
             self.use_aiofiles = self._compute_aiofiles(self.use_aiofiles)
 
-        if self.env.debug_logging:
+        if "PARFIVE_DEBUG" in os.environ:
             self.log_level = "DEBUG"
 
 
-class DownloaderConfig(BaseSettings):
+@dataclass
+class EnvConfig:
+    """
+    Configuration read from environment variables.
+    """
+
+    # Session scoped env vars
+    serial_mode: bool = field(default=False, init=False)
+    disable_range: bool = field(default=False, init=False)
+    hide_progress: bool = field(default=False, init=False)
+
+    def __post_init__(self):
+        self.serial_mode = "PARFIVE_SINGLE_DOWNLOAD" in os.environ
+        self.disable_range = "PARFIVE_DISABLE_RANGE" in os.environ
+        self.hide_progress = "PARFIVE_HIDE_PROGRESS" in os.environ
+
+
+@dataclass
+class DownloaderConfig(SessionConfig):
     """
     Hold all downloader session state.
     """
@@ -158,30 +164,48 @@ class DownloaderConfig(BaseSettings):
     max_splits: int = 5
     progress: bool = True
     overwrite: Union[bool, Literal["unique"]] = False
-    headers: Optional[Dict[str, str]] = Field(default_factory=_default_headers)
-    config: Optional[SessionConfig] = Field(default_factory=SessionConfig)
+    # headers and use_aiofiles are deprecated here.
+    # The arguments passed to SessionConfig take precedence.
+    # To make this priority work, the defaults on SessionConfig
+    # are that these two arguments default to None.
+    # When these are removed after the deprecation period, the defaults here
+    # should be moved to SessionConifg
+    headers: Optional[Dict[str, str]] = field(default_factory=_default_headers)
+    use_aiofiles: Optional[bool] = False
+    config: InitVar[Optional[SessionConfig]] = None
+    env: EnvConfig = field(default_factory=EnvConfig)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if self.config is None:
-            self.config = SessionConfig()
+    def __post_init__(self, config):
+        if config is None:
+            config = SessionConfig()
+        if not isinstance(config, SessionConfig):
+            raise TypeError("config argument should be a parfive.config.SessionConfig instance")
 
         self.max_conn = 1 if self.env.serial_mode else self.max_conn
         self.max_splits = 1 if self.env.serial_mode or self.env.disable_range else self.max_splits
         self.progress = False if self.env.hide_progress else self.progress
 
+        # Default headers and use_aiofiles if None
+        if self.headers is None:
+            self.headers = self.__dataclass_fields__["headers"].default_factory()
+        if self.use_aiofiles is None:
+            self.use_aiofiles = self.__dataclass_fields__["use_aiofiles"].default
+
+        # Squash the properties passed by the user in config onto this object.
+        for name, value in asdict(config).items():
+            # Remove this check after deprecation period
+            if name in ("headers", "use_aiofiles"):
+                continue
+            setattr(self, name, value)
+
         if self.progress is False:
-            self.config.file_progress = False
+            self.file_progress = False
 
         # Remove this after deprecation period
-        if self.config.headers is not None:
-            self.headers = self.config.headers
-        if self.headers is None:
-            self.headers = _default_headers()
-
-    def __getattr__(self, __name: str) -> Any:
-        return getattr(self.config, __name)
+        if config.headers is not None:
+            self.headers = config.headers
+        if config.use_aiofiles is not None:
+            self.use_aiofiles = self._compute_aiofiles(config.use_aiofiles)
 
     @property
     def aiohttp_session(self) -> aiohttp.ClientSession:

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -77,7 +77,8 @@ class Downloader:
         progress: bool = True,
         overwrite: Union[bool, Literal["unique"]] = False,
         headers: Optional[Dict[str, str]] = None,
-        config: Optional[SessionConfig] = None,
+        use_aiofiles: Optional[bool] = None,
+        config: SessionConfig = None,
     ):
 
         msg = (
@@ -86,6 +87,8 @@ class Downloader:
         )
         if headers is not None:
             warnings.warn(msg.format("headers"), ParfiveFutureWarning)
+        if use_aiofiles is not None:
+            warnings.warn(msg.format("use_aiofiles"), ParfiveFutureWarning)
 
         self.config = DownloaderConfig(
             max_conn=max_conn,
@@ -93,6 +96,7 @@ class Downloader:
             progress=progress,
             overwrite=overwrite,
             headers=headers,
+            use_aiofiles=use_aiofiles,
             config=config,
         )
 

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -77,7 +77,6 @@ class Downloader:
         progress: bool = True,
         overwrite: Union[bool, Literal["unique"]] = False,
         headers: Optional[Dict[str, str]] = None,
-        use_aiofiles: Optional[bool] = None,
         config: SessionConfig = None,
     ):
 
@@ -87,8 +86,6 @@ class Downloader:
         )
         if headers is not None:
             warnings.warn(msg.format("headers"), ParfiveFutureWarning)
-        if use_aiofiles is not None:
-            warnings.warn(msg.format("use_aiofiles"), ParfiveFutureWarning)
 
         self.config = DownloaderConfig(
             max_conn=max_conn,
@@ -96,7 +93,6 @@ class Downloader:
             progress=progress,
             overwrite=overwrite,
             headers=headers,
-            use_aiofiles=use_aiofiles,
             config=config,
         )
 

--- a/parfive/tests/test_aiofiles.py
+++ b/parfive/tests/test_aiofiles.py
@@ -17,7 +17,7 @@ def test_enable_aiofiles_constructor(use_aiofiles):
     ), f"expected={use_aiofiles}, got={dl.config.use_aiofiles}"
 
 
-@patch.dict(os.environ, {"PARFIVE_OVERWRITE_ENABLE_AIOFILES": "True"})
+@patch.dict(os.environ, {"PARFIVE_OVERWRITE_ENABLE_AIOFILES": "some_value_to_enable_it"})
 @pytest.mark.parametrize("use_aiofiles", [True, False])
 def test_enable_aiofiles_env_overwrite_always_enabled(use_aiofiles):
     dl = Downloader(config=parfive.SessionConfig(use_aiofiles=use_aiofiles))

--- a/parfive/tests/test_config.py
+++ b/parfive/tests/test_config.py
@@ -1,3 +1,5 @@
+import ssl
+
 import aiohttp
 import pytest
 
@@ -16,30 +18,12 @@ def test_session_config_defaults():
     assert c.http_proxy is None
     assert c.https_proxy is None
     assert c.chunksize == 1024
+    assert c.use_aiofiles is False
 
     # Deprecated behaviour
     assert c.headers is None
-    assert c.use_aiofiles is None
-    # assert c.use_aiofiles is False
     # assert isinstance(c.headers, dict)
     # assert "User-Agent" in c.headers
-
-
-def test_use_aiofiles_deprecated():
-    c = DownloaderConfig()
-    assert c.use_aiofiles is False
-    c = DownloaderConfig(use_aiofiles=None)
-    assert c.use_aiofiles is False
-    c = DownloaderConfig(use_aiofiles=True)
-    assert c.use_aiofiles is True
-    c = DownloaderConfig(config=SessionConfig(use_aiofiles=True))
-    assert c.use_aiofiles is True
-    c = DownloaderConfig(config=SessionConfig(use_aiofiles=False))
-    assert c.use_aiofiles is False
-    c = DownloaderConfig(use_aiofiles=True, config=SessionConfig(use_aiofiles=False))
-    assert c.use_aiofiles is False
-    c = DownloaderConfig(use_aiofiles=False, config=SessionConfig(use_aiofiles=True))
-    assert c.use_aiofiles is True
 
 
 def test_headers_deprecated():
@@ -73,10 +57,12 @@ def test_headers_deprecated():
 
 
 def test_deprecated_downloader_arguments():
-    with pytest.warns(ParfiveFutureWarning, match="use_aiofiles keyword"):
-        d = Downloader(use_aiofiles=False)
-    assert d.config.use_aiofiles is False
-
     with pytest.warns(ParfiveFutureWarning, match="headers keyword"):
         d = Downloader(headers="ni")
     assert d.config.headers == "ni"
+
+
+def test_ssl_context():
+    ssl_ctx = ssl.create_default_context()
+    c = SessionConfig(aiohttp_session_kwargs={"context": ssl_ctx})
+    d = Downloader(config=c)

--- a/parfive/tests/test_config.py
+++ b/parfive/tests/test_config.py
@@ -16,30 +16,30 @@ def test_session_config_defaults():
     assert c.http_proxy is None
     assert c.https_proxy is None
     assert c.chunksize == 1024
-    assert c.use_aiofiles is False
 
     # Deprecated behaviour
     assert c.headers is None
+    assert c.use_aiofiles is None
+    # assert c.use_aiofiles is False
     # assert isinstance(c.headers, dict)
     # assert "User-Agent" in c.headers
 
 
-def test_session_config_env_defaults():
-    c = SessionConfig()
-    assert c.env.serial_mode is False
-    assert c.env.disable_range is False
-    assert c.env.hide_progress is False
-    assert c.env.timeout_total == 0
-    assert c.env.timeout_sock_read == 90
-
-
-def test_use_aiofiles():
+def test_use_aiofiles_deprecated():
     c = DownloaderConfig()
     assert c.use_aiofiles is False
+    c = DownloaderConfig(use_aiofiles=None)
+    assert c.use_aiofiles is False
+    c = DownloaderConfig(use_aiofiles=True)
+    assert c.use_aiofiles is True
     c = DownloaderConfig(config=SessionConfig(use_aiofiles=True))
     assert c.use_aiofiles is True
     c = DownloaderConfig(config=SessionConfig(use_aiofiles=False))
     assert c.use_aiofiles is False
+    c = DownloaderConfig(use_aiofiles=True, config=SessionConfig(use_aiofiles=False))
+    assert c.use_aiofiles is False
+    c = DownloaderConfig(use_aiofiles=False, config=SessionConfig(use_aiofiles=True))
+    assert c.use_aiofiles is True
 
 
 def test_headers_deprecated():
@@ -73,6 +73,10 @@ def test_headers_deprecated():
 
 
 def test_deprecated_downloader_arguments():
+    with pytest.warns(ParfiveFutureWarning, match="use_aiofiles keyword"):
+        d = Downloader(use_aiofiles=False)
+    assert d.config.use_aiofiles is False
+
     with pytest.warns(ParfiveFutureWarning, match="headers keyword"):
-        d = Downloader(headers={"ni": "shrubbery"})
-    assert d.config.headers == {"ni": "shrubbery"}
+        d = Downloader(headers="ni")
+    assert d.config.headers == "ni"

--- a/parfive/tests/test_config.py
+++ b/parfive/tests/test_config.py
@@ -26,6 +26,15 @@ def test_session_config_defaults():
     # assert "User-Agent" in c.headers
 
 
+def test_session_config_env_defaults():
+    c = SessionConfig()
+    assert c.env.serial_mode is False
+    assert c.env.disable_range is False
+    assert c.env.hide_progress is False
+    assert c.env.timeout_total == 0
+    assert c.env.timeout_sock_read == 90
+
+
 def test_headers_deprecated():
     c = DownloaderConfig()
     assert isinstance(c.headers, dict)

--- a/parfive/tests/test_config.py
+++ b/parfive/tests/test_config.py
@@ -72,6 +72,8 @@ def test_deprecated_downloader_arguments():
 
 
 def test_ssl_context():
+    # Assert that the unpickalable SSL context object doesn't anger the
+    # dataclass gods
     ssl_ctx = ssl.create_default_context()
     c = SessionConfig(aiohttp_session_kwargs={"context": ssl_ctx})
     d = Downloader(config=c)

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -461,7 +461,7 @@ def test_proxy_passed_as_kwargs_to_get(tmpdir, url, proxy):
         ("GET", url),
         {
             "allow_redirects": True,
-            "timeout": ClientTimeout(total=0.0, connect=None, sock_read=90.0, sock_connect=None),
+            "timeout": ClientTimeout(total=0, connect=None, sock_read=90, sock_connect=None),
             "proxy": proxy,
         },
     ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ python_requires = >=3.7
 install_requires =
   tqdm >= 4.27.0
   aiohttp
-  pydantic
   typing_extensions;python_version<'3.8'
 setup_requires =
   setuptools_scm


### PR DESCRIPTION
@solardrew found an issue with pydantic where you couldn't pass the SSL Context into `aiohttp_session_kwargs`, I couldn't figure it out so I gave up