### PR TITLE
Allow the user to override the `aiohttp.ClientSession` with a callback

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -380,7 +380,7 @@ class Downloader:
             return contextlib.contextmanager(lambda: iter([None]))()
 
     async def _run_http_download(self, main_pb):
-        async with self.config.aiohttp_session as session:
+        async with self.config.aiohttp_client_session() as session:
             self._generate_tokens()
             futures = await self._run_from_queue(
                 self.http_queue.generate_queue(),

--- a/parfive/tests/test_config.py
+++ b/parfive/tests/test_config.py
@@ -10,8 +10,7 @@ from parfive.utils import ParfiveFutureWarning
 
 def test_session_config_defaults():
     c = SessionConfig()
-    assert isinstance(c.aiohttp_session_kwargs, dict)
-    assert not c.aiohttp_session_kwargs
+    assert callable(c.aiohttp_session_generator)
     assert isinstance(c.timeouts, aiohttp.ClientTimeout)
     assert c.timeouts.total == 0
     assert c.timeouts.sock_read == 90
@@ -74,6 +73,6 @@ def test_deprecated_downloader_arguments():
 def test_ssl_context():
     # Assert that the unpickalable SSL context object doesn't anger the
     # dataclass gods
-    ssl_ctx = ssl.create_default_context()
-    c = SessionConfig(aiohttp_session_kwargs={"context": ssl_ctx})
+    gen = lambda config: aiohttp.ClientSession(context=ssl.create_default_context())
+    c = SessionConfig(aiohttp_session_generator=gen)
     d = Downloader(config=c)


### PR DESCRIPTION
This makes it possible to setup things like `TCPConnection` which need an async context.

Requires #98 