### PR TITLE
Add urls to results

### DIFF
--- a/parfive/results.py
+++ b/parfive/results.py
@@ -22,14 +22,16 @@ class Results(UserList):
     """
     The results of a download from `parfive.Downloader.download`.
 
-    This object contains the filenames of successful downloads as well
-    as a list of any errors encountered in the `~parfive.Results.errors`
+    This object contains the filenames of successful downloads as well,
+    a list of all urls requested in the `~parfive.Results.urls` property
+    and a list of any errors encountered in the `~parfive.Results.errors`
     property.
     """
 
-    def __init__(self, *args, errors=None):
+    def __init__(self, *args, errors=None, urls=None):
         super().__init__(*args)
         self._errors = errors or list()
+        self._urls = urls or list()
 
     def _get_nice_resp_repr(self, response):
         # This is a modified version of aiohttp.ClientResponse.__repr__
@@ -63,6 +65,10 @@ class Results(UserList):
         out += str(self)
         return out
 
+    def append(self, *, path, url):
+        super().append(path)
+        self._urls.append(url)
+
     def add_error(self, filename, url, exception):
         """
         Add an error to the results.
@@ -82,3 +88,11 @@ class Results(UserList):
         ``exception`` is the error raised during download.
         """
         return self._errors
+
+    @property
+    def urls(self):
+        """
+        A list of requested urls.
+
+        """
+        return self._urls

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -47,6 +47,7 @@ def test_download(httpserver, tmpdir):
     assert dl.queued_downloads == 1
 
     f = dl.download()
+    f.urls == [httpserver.url]
     validate_test_file(f)
 
 
@@ -302,7 +303,10 @@ def test_failed_download():
 def test_results():
     res = Results()
 
-    res.append("hello")
+    res.append(path="hello", url="aurl")
+
+    assert res[0] == "hello"
+    assert res.urls[0] == "aurl"
 
     res.add_error("wibble", "notaurl", "out of cheese")
 


### PR DESCRIPTION
Trying to fix #71 specifically and as a baby step for sunpy/sunpy/issues/7140

Currently modified the return values from `_get_http` and `_get_ftp` and added a new `urls` property to the `Result` object. Not sure if it might be better to create a new object or named tuple to hold the url and str(path) and pass that around? 