### PR TITLE
Fix test issue where warning was being raised but not captured

### DIFF
--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -599,6 +599,7 @@ def test_download_out_of_main_thread(httpserver, tmpdir, recwarn):
     thread.join()
 
     validate_test_file(thread.result)
+
     # We use recwarn here as for some reason pytest.warns did not reliably pickup this warning.
     assert len(recwarn) > 0
     assert any(

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -601,5 +601,10 @@ def test_download_out_of_main_thread(httpserver, tmpdir, recwarn):
     validate_test_file(thread.result)
 
     assert len(recwarn) > 0
-    assert any(['This download has been started in a thread which is not the main thread. You will not be able to interrupt the download.' ==
-                w.message.args[0] for w in recwarn])
+    assert any(
+        [
+            "This download has been started in a thread which is not the main thread. You will not be able to interrupt the download."
+            == w.message.args[0]
+            for w in recwarn
+        ]
+    )

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -599,7 +599,7 @@ def test_download_out_of_main_thread(httpserver, tmpdir, recwarn):
     thread.join()
 
     validate_test_file(thread.result)
-    # We use recwarn here as for some reason pytest.warns did not reliably pickup this warning. 
+    # We use recwarn here as for some reason pytest.warns did not reliably pickup this warning.
     assert len(recwarn) > 0
     assert any(
         [

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -599,7 +599,7 @@ def test_download_out_of_main_thread(httpserver, tmpdir, recwarn):
     thread.join()
 
     validate_test_file(thread.result)
-
+    # We use recwarn here as for some reason pytest.warns did not reliably pickup this warning. 
     assert len(recwarn) > 0
     assert any(
         [

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -578,7 +578,10 @@ class CustomThread(threading.Thread):
         super().__init__(*args, **kwargs)
 
     def run(self):
-        self.result = self._target(*self._args, **self._kwargs)
+        try:
+            self.result = self._target(*self._args, **self._kwargs)
+        finally:
+            del self._target, self._args, self._kwargs
 
 
 @skip_windows


### PR DESCRIPTION
So if you look at the test output the warning is raised but `pytest.warn` doesn't seem to capture it but recwarn does?

```
pytest  -k test_download_out_of_main_thread                                                                                                                                                                   1 ✘  parfive 
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.11.7, pytest-8.1.1, pluggy-1.4.0
rootdir: /Users/sm/Projects/parfive
configfile: setup.cfg
plugins: cov-5.0.0, socket-0.7.0, asyncio-0.23.6, localserver-0.8.1
asyncio: mode=Mode.STRICT
collected 60 items / 59 deselected / 1 selected

parfive/tests/test_downloader.py F                                                                                                                                                                                                                                       [100%]

=================================================================================================================================== FAILURES ===================================================================================================================================
_______________________________________________________________________________________________________________________ test_download_out_of_main_thread _______________________________________________________________________________________________________________________

httpserver = <ContentServer(<class 'pytest_localserver.http.ContentServer'>, started 6117765120)>, tmpdir = '/private/var/folders/h1/wy_cdhsj1c9_9pr0x9shjrcr0000gp/T/pytest-of-sm/pytest-111/test_download_out_of_main_thre0'

    @skip_windows
    def test_download_out_of_main_thread(httpserver, tmpdir):
        tmpdir = str(tmpdir)
        httpserver.serve_content(
            "SIMPLE  = T", headers={"Content-Disposition": "attachment; filename=testfile.fits"}
        )
        dl = Downloader()

        dl.enqueue_file(httpserver.url, path=Path(tmpdir), max_splits=None)

        thread = CustomThread(target=dl.download)
        thread.start()

>       with pytest.warns(
            UserWarning,
            match="This download has been started in a thread*.",
        ):
E       Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
E        Emitted warnings: [].

parfive/tests/test_downloader.py:545: Failed
----------------------------------------------------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------------------------------------------------
Files Downloaded: 100%|██████████| 1/1 [00:00<00:00, 287.03file/s]
------------------------------------------------------------------------------------------------------------------------------ Captured log call -------------------------------------------------------------------------------------------------------------------------------
INFO     werkzeug:_internal.py:96 127.0.0.1 - - [04/Apr/2024 18:20:57] "GET / HTTP/1.1" 200 -
INFO     werkzeug:_internal.py:96 127.0.0.1 - - [04/Apr/2024 18:20:57] "GET / HTTP/1.1" 200 -
=============================================================================================================================== warnings summary ===============================================================================================================================
parfive/tests/test_downloader.py::test_download_out_of_main_thread
  /Users/sm/Projects/parfive/parfive/downloader.py:230: UserWarning: This download has been started in a thread which is not the main thread. You will not be able to interrupt the download.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================== short test summary info ============================================================================================================================
FAILED parfive/tests/test_downloader.py::test_download_out_of_main_thread - Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
================================================================================================================= 1 failed, 59 deselected, 1 warning in 0.64s ================================================================================================================
```