### PR TITLE
Fix a bug where result urls were not updated in retry

### DIFF
--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -369,8 +369,10 @@ class Downloader:
 
         new_res = self.download()
 
+        # Append paths and urls overwrite errors
         results += new_res
-        results._errors = new_res._errors
+        results._urls += new_res.urls
+        results._errors = new_res.errors
 
         return results
 

--- a/parfive/tests/localserver.py
+++ b/parfive/tests/localserver.py
@@ -56,7 +56,7 @@ class SimpleTestServer(BaseTestServer):
         status = "200 OK"
         response_headers = [
             ("Content-type", "text/plain"),
-            ("Content-Disposition", "attachment; filename=testfile_{self.request_number}.txt"),
+            ("Content-Disposition", f"attachment; filename=testfile_{self.request_number}.txt"),
         ]
         start_response(status, response_headers)
         return [b"Hello world!\n"]

--- a/parfive/tests/test_downloader.py
+++ b/parfive/tests/test_downloader.py
@@ -47,7 +47,8 @@ def test_download(httpserver, tmpdir):
     assert dl.queued_downloads == 1
 
     f = dl.download()
-    f.urls == [httpserver.url]
+    assert len(f.urls) == 1
+    assert f.urls[0] == httpserver.url
     validate_test_file(f)
 
 
@@ -343,7 +344,7 @@ def test_retry(tmpdir, testserver):
 
     nn = 5
     for i in range(nn):
-        dl.enqueue_file(testserver.url, path=tmpdir)
+        dl.enqueue_file(testserver.url + f"/{i}", path=tmpdir)
 
     f = dl.download()
 
@@ -354,6 +355,11 @@ def test_retry(tmpdir, testserver):
 
     assert len(f2) == nn
     assert len(f2.errors) == 0
+    assert ["0", "1", "3", "4", "2"] == [url[-1] for url in f2.urls]
+    assert "testfile_1.txt" == Path(f2[0]).name
+    # there are two requests made per file one for size and one download?
+    # Todo change handler to use path to create name not request call count
+    assert "testfile_10.txt" == Path(f2[-1]).name
 
 
 def test_empty_retry():


### PR DESCRIPTION
This is actually what prompted #152 but I forgot to implement this basic version after creating the issue, my bad.