### PR TITLE
Use a HEAD for the first request

### DIFF
--- a/parfive/conftest.py
+++ b/parfive/conftest.py
@@ -2,12 +2,12 @@ from functools import partial
 
 import pytest
 
-from parfive.tests.localserver import MultiPartTestServer, SimpleTestServer, error_on_nth_request
+from parfive.tests.localserver import MultiPartTestServer, SimpleTestServer, error_on_paths
 
 
 @pytest.fixture
 def testserver():
-    server = SimpleTestServer(callback=partial(error_on_nth_request, 2))
+    server = SimpleTestServer(callback=partial(error_on_paths, ["testfile_2.txt"]))
     server.start_server()
     yield server
     server.stop_server()

--- a/parfive/downloader.py
+++ b/parfive/downloader.py
@@ -30,6 +30,7 @@ from .utils import (
     get_http_size,
     remove_file,
     run_task_in_thread,
+    session_head_or_get,
 )
 
 try:
@@ -520,7 +521,7 @@ class Downloader:
             elif scheme == "https":
                 kwargs["proxy"] = self.config.https_proxy
 
-            async with session.get(url, timeout=self.config.timeouts, **kwargs) as resp:
+            async with session_head_or_get(session, url, timeout=self.config.timeouts, **kwargs) as resp:
                 parfive.log.debug(
                     "%s request made to %s with headers=%s",
                     resp.request_info.method,

--- a/parfive/tests/test_downloader_multipart.py
+++ b/parfive/tests/test_downloader_multipart.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from parfive import Downloader
-from parfive.tests.localserver import error_on_nth_request
+from parfive.tests.localserver import error_on_nth_get_request
 from parfive.utils import MultiPartDownloadError
 
 
@@ -23,7 +23,7 @@ def test_multipart(multipartserver, tmp_path):
 
 
 def test_multipart_with_error(multipartserver, tmp_path):
-    multipartserver.callback = partial(error_on_nth_request, 3)
+    multipartserver.callback = partial(error_on_nth_get_request, 3)
     dl = Downloader(progress=False)
     max_splits = 5
     dl.enqueue_file(multipartserver.url, path=tmp_path, max_splits=max_splits)

--- a/parfive/utils.py
+++ b/parfive/utils.py
@@ -3,7 +3,7 @@ import hashlib
 import os
 import pathlib
 import warnings
-from collections.abc import Generator
+from collections.abc import AsyncIterator, Generator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from itertools import count
@@ -256,7 +256,7 @@ async def cancel_task(task: asyncio.Task) -> bool:
 
 
 @asynccontextmanager
-async def session_head_or_get(session: aiohttp.ClientSession, url: str, **kwargs):
+async def session_head_or_get(session: aiohttp.ClientSession, url: str, **kwargs: dict) -> AsyncIterator:
     """
     Try and make a HEAD request to the resource and fallback to a get
     request if that fails.


### PR DESCRIPTION
This feels like something that should always have been the case, but to make sure we don't change behaviour we fall back to GET.